### PR TITLE
cmake: Remove install of configurations/ dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,5 +152,4 @@ add_xdp_prog(xdp_kern_avtp_vid400)
 
 install(TARGETS reference DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT binaries)
 install(TARGETS mirror DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT binaries)
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/configurations/ DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/testbench/configurations)
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/tests/ DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/testbench/tests)


### PR DESCRIPTION
When generating the Debian package, the build fails:
```
$ dpkg-buildpackage -b
. . .
CMake Error at cmake_install.cmake:102 (file):
  file INSTALL cannot find
  "/bla/bla/TSN-Testbench/configurations": No such
  file or directory.
```

Former configurations directory has been distributed into the tests directory.

This patch removes the references to configurations/ in the build system.
