### PR TITLE
dcp_thread: add back setting of source MAC address

### DIFF
--- a/src/dcp_thread.c
+++ b/src/dcp_thread.c
@@ -164,18 +164,11 @@ static void *dcp_tx_thread_routine(void *data)
 	pthread_cond_t *cond = &thread_context->data_cond_var;
 	pthread_mutex_t *mutex = &thread_context->data_mutex;
 	struct sockaddr_ll destination;
-	unsigned char source[ETH_ALEN];
 	uint64_t sequence_counter = 0;
 	unsigned int if_index;
-	int ret, socket_fd;
+	int socket_fd;
 
 	socket_fd = thread_context->socket_fd;
-
-	ret = get_interface_mac_address(app_config.dcp_interface, source, ETH_ALEN);
-	if (ret < 0) {
-		log_message(LOG_LEVEL_ERROR, "DcpTx: Failed to get Source MAC address!\n");
-		return NULL;
-	}
 
 	if_index = if_nametoindex(app_config.dcp_interface);
 	if (!if_index) {
@@ -190,7 +183,7 @@ static void *dcp_tx_thread_routine(void *data)
 	memcpy(destination.sll_addr, app_config.dcp_destination, ETH_ALEN);
 
 	dcp_initialize_frames(thread_context->tx_frame_data, app_config.dcp_num_frames_per_cycle,
-			      source);
+			      thread_context->source);
 
 	while (!thread_context->stop) {
 		struct timespec timeout;

--- a/src/dcp_thread.c
+++ b/src/dcp_thread.c
@@ -167,9 +167,15 @@ static void *dcp_tx_thread_routine(void *data)
 	unsigned char source[ETH_ALEN];
 	uint64_t sequence_counter = 0;
 	unsigned int if_index;
-	int socket_fd;
+	int ret, socket_fd;
 
 	socket_fd = thread_context->socket_fd;
+
+	ret = get_interface_mac_address(app_config.dcp_interface, source, ETH_ALEN);
+	if (ret < 0) {
+		log_message(LOG_LEVEL_ERROR, "DcpTx: Failed to get Source MAC address!\n");
+		return NULL;
+	}
 
 	if_index = if_nametoindex(app_config.dcp_interface);
 	if (!if_index) {


### PR DESCRIPTION
Hello Kurt,
In commit dcp: Switch to sendmmsg() and recvmmsg with the id 362ba5917d37df35b1640ec5a2bf9b2794ec566e the setting of the MAC address for DCP frames was probably mistakenly replaced by the setting of the interface index instead of adding the setting of the indexes. So the DCP frames are send with the MAC address 00:00:00:00:00:00. The commit fixes this by adding the old code again.